### PR TITLE
not force temp_customer_id (Ruby 1.9)

### DIFF
--- a/lib/ravelin/event.rb
+++ b/lib/ravelin/event.rb
@@ -43,7 +43,7 @@ module Ravelin
 
     def validate_top_level_payload_params
       validate_customer_id_presence_on :order, :paymentmethod,
-        :pretransaction, :transaction, :label
+        :pretransaction, :transaction, :label, :login
       case self.name
         when :customer
           validate_payload_inclusion_of :customer
@@ -53,8 +53,6 @@ module Ravelin
           validate_payload_inclusion_of :'voucher_redemption'
         when :pretransaction, :transaction
           validate_payload_inclusion_of :order_id, :payment_method_id
-        when :login
-          validate_payload_inclusion_of :customer_id, :temp_customer_id
         when :checkout
           validate_payload_inclusion_of :customer, :order,
             :payment_method, :transaction

--- a/lib/ravelin/version.rb
+++ b/lib/ravelin/version.rb
@@ -1,3 +1,3 @@
 module Ravelin
-  VERSION = "0.1.5.curb"
+  VERSION = "0.1.6.curb"
 end

--- a/spec/ravelin/client_spec.rb
+++ b/spec/ravelin/client_spec.rb
@@ -11,7 +11,7 @@ describe Ravelin::Client do
   end
 
   shared_context 'event setup and stubbing' do
-    let(:client) { described_class.new('abc') }
+    let(:client) { described_class.new(api_key: 'abc') }
     let(:event_name) { 'foobar' }
     let(:event_payload) { { id: 'ch-123' } }
     let(:event) do
@@ -92,7 +92,7 @@ describe Ravelin::Client do
   end
 
   describe '#post' do
-    let(:client) { described_class.new('abc') }
+    let(:client) { described_class.new(api_key: 'abc') }
     let(:event) do
       double('event', name: 'ping', serializable_hash: { name: 'value' })
     end

--- a/spec/ravelin/event_spec.rb
+++ b/spec/ravelin/event_spec.rb
@@ -19,9 +19,9 @@ describe Ravelin::Event do
 
       it 'left as they are' do
         expect(event.serializable_hash).to eq({
-          'name' => 'John',
-          'timestamp' => 12345
-        })
+            'name' => 'John',
+            'timestamp' => 12345
+          })
       end
     end
 
@@ -30,34 +30,36 @@ describe Ravelin::Event do
 
       it 'converts the Ravelin objects to hash with camelcase keys' do
         expect(event.serializable_hash).to eq({
-          'timestamp' => 12345,
-          'dummy' => { 'name' => 'Fraudster' }
-        })
+            'timestamp' => 12345,
+            'dummy' => { 'name' => 'Fraudster' }
+          })
       end
     end
   end
 
   describe '#validate_top_level_payload_params' do
     context 'customer presence required' do
-      it 'throws ArgumentError with no customer_id or temp_customer_id' do
-        expect {
-          described_class.new(:order, {})
-        }.to raise_exception(
-          ArgumentError,
-          /payload missing customer_id or temp_customer_id/
-        )
-      end
+      [:login, :order, :paymentmethod].each do |event|
+        it "throws ArgumentError with no customer_id or temp_customer_id for #{event}" do
+          expect {
+            described_class.new(event, {})
+          }.to raise_exception(
+            ArgumentError,
+            /payload missing customer_id or temp_customer_id/
+          )
+        end
 
-      it 'accepts customer_id' do
-        expect {
-          described_class.new(:order, { customer_id: 1 })
-        }.to_not raise_exception
-      end
+        it "accepts customer_id for #{event}" do
+          expect {
+            described_class.new(event, { customer_id: 1 })
+          }.to_not raise_exception
+        end
 
-      it 'accepts temp_customer_id' do
-        expect {
-          described_class.new(:order, { temp_customer_id: 2 })
-        }.to_not raise_exception
+        it "accepts temp_customer_id for #{event}" do
+          expect {
+            described_class.new(event,{ temp_customer_id: 2 })
+          }.to_not raise_exception
+        end
       end
     end
 


### PR DESCRIPTION
Same as #2 but for ruby 1.9 (RC)